### PR TITLE
CSS minifier destroys multi-browser gradients

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,11 @@ Installation
 ------------
 
 The media-bundler is a reusable app, so to install it all you have to do is
-clone the source tree, put it somewhere in Django's ``PYTHONPATH``, and add it
-to ``INSTALLED_APPS`` in ``settings.py``.
+clone the source tree, put it somewhere in Django's ``PYTHONPATH``.
+
+You can use pip with ``pip install git+https://github.com/rnk/django-media-bundler/``.
+
+After that add ``media_bundler`` to the list of applications in ``INSTALLED_APPS`` in ``settings.py``.
 
 Usage
 -----
@@ -94,7 +97,7 @@ Describe the Javascript and CSS bundles you would like to create in
 
 By default, deferring is enabled, and bundling is disabled when
 ``settings.DEBUG`` is ``True``.  You can override those values in your settings
-module.  See the ``media_bundle.default_settings`` module for more info.  
+module by setting the boolean variables ``DEFER_JAVASCRIPT`` and ``USE_BUNDLES``.  See the ``media_bundle.default_settings`` module for details on all the options.  
 
 To source your Javascript and CSS, put ``{% load bundler_tags %}`` at the top of
 your template, and wherever you used to write this::

--- a/media_bundler/bundler.py
+++ b/media_bundler/bundler.py
@@ -100,7 +100,7 @@ class Bundle(object):
             versioner.update_bundle_version(self)
 
     def do_text_bundle(self, minifier=None):
-        with open(self.get_bundle_path(), "w") as output:
+        with open(self.get_bundle_path(), "w+") as output:
             generator = concatenate_files(self.get_paths())
             if minifier:
                 # Eventually we should use generators to concatenate and minify
@@ -208,7 +208,7 @@ class PngSpriteBundle(Bundle):
 
     def generate_css(self, packing):
         """Generate the background offset CSS rules."""
-        with open(self.css_file, "w") as css:
+        with open(self.css_file, "w+") as css:
             css.write("/* Generated classes for django-media-bundler sprites.  "
                       "Don't edit! */\n")
             props = {

--- a/media_bundler/bundler.py
+++ b/media_bundler/bundler.py
@@ -62,7 +62,8 @@ class Bundle(object):
         if attrs["type"] == "javascript":
             return JavascriptBundle(attrs["name"], attrs["path"], attrs["url"],
                                     attrs["files"], attrs["type"],
-                                    attrs.get("minify", False))
+                                    attrs.get("minify", False),
+                                    attrs.get("minify_new_lines", True))
         elif attrs["type"] == "css":
             return CssBundle(attrs["name"], attrs["path"], attrs["url"],
                              attrs["files"], attrs["type"],
@@ -113,15 +114,21 @@ class JavascriptBundle(Bundle):
 
     """Bundle for JavaScript."""
 
-    def __init__(self, name, path, url, files, type, minify):
+    def __init__(self, name, path, url, files, type, minify, minify_new_lines):
         super(JavascriptBundle, self).__init__(name, path, url, files, type)
         self.minify = minify
+        self.minify_new_lines = minify_new_lines
 
     def get_extension(self):
         return ".js"
 
     def _make_bundle(self):
-        minifier = jsmin if self.minify else None
+        minifier = None
+        if self.minify:
+            if self.minify_new_lines:
+                minifier = jsmin
+            else:
+                minifier = jsmin_keep_new_lines
         self.do_text_bundle(minifier)
 
 

--- a/media_bundler/bundler.py
+++ b/media_bundler/bundler.py
@@ -89,9 +89,9 @@ class Bundle(object):
         return os.path.join(self.path, filename)
 
     def get_bundle_url(self):
-        unversioned = self.get_bundle_filename()
-        filename = versioning.get_bundle_versions().get(self.name, unversioned)
-        return self.url + filename
+        filename = self.get_bundle_filename()
+        version = versioning.get_bundle_versions().get(self.name, filename)
+        return self.url + filename + "?" + version
 
     def make_bundle(self, versioner):
         self._make_bundle()

--- a/media_bundler/bundler.py
+++ b/media_bundler/bundler.py
@@ -11,7 +11,7 @@ from StringIO import StringIO
 
 from media_bundler.conf import bundler_settings
 from media_bundler.bin_packing import Box, pack_boxes
-from media_bundler.jsmin import jsmin
+from media_bundler.jsmin import jsmin, jsmin_keep_new_lines
 from media_bundler.cssmin import minify_css
 from media_bundler import versioning
 

--- a/media_bundler/cssmin.py
+++ b/media_bundler/cssmin.py
@@ -17,23 +17,3 @@ def minify_css(css):
     # spaces may be safely collapsed as generated content will collapse them anyway
     css = re.sub(r'\s+', " ", css)
     return css
-    #return "".join(generate_rules(css))
-
-def generate_rules(css):
-    for rule in re.findall(r'([^{]+){([^}]*)}', css):
-        selectors = []
-        for selector in rule[0].split(','):
-            selectors.append(selector.strip())
-        # order is important, but we still want to discard repetitions
-        properties = {}
-        porder  = []
-        for prop in re.findall('(.*?):(.*?)(;|$)', rule[1]):
-            key = prop[0].strip().lower()
-            if key not in porder:
-                porder.insert(0, key)
-            properties[ key ] = prop[1].strip()
-        porder.reverse()
-        # output rule if it contains any declarations
-        if len(properties) > 0:
-            s = ";".join(key + ":" + properties[key] for key in porder)
-            yield ",".join(selectors) + "{" + s + "}"

--- a/media_bundler/cssmin.py
+++ b/media_bundler/cssmin.py
@@ -16,7 +16,8 @@ def minify_css(css):
     css = re.sub(r'url\((["\'])([^)]*)\1\)', "url(\\2)", css)
     # spaces may be safely collapsed as generated content will collapse them anyway
     css = re.sub(r'\s+', " ", css)
-    return "".join(generate_rules(css))
+    return css
+    #return "".join(generate_rules(css))
 
 def generate_rules(css):
     for rule in re.findall(r'([^{]+){([^}]*)}', css):

--- a/media_bundler/jsmin.py
+++ b/media_bundler/jsmin.py
@@ -104,7 +104,7 @@ class JavascriptMinify(object):
             p = self._peek()
             if p == '/':
                 c = self._get()
-                while c >= '\n':
+                while c > '\n':
                     c = self._get()
                 return c
             if p == '*':

--- a/media_bundler/versioning.py
+++ b/media_bundler/versioning.py
@@ -81,16 +81,7 @@ class VersioningBase(object):
 
     def update_bundle_version(self, bundle):
         version = self.get_version(bundle)
-        orig_path = bundle.get_bundle_path()
-        dir, basename = os.path.split(orig_path)
-        if '.' in basename:
-            name, _, extension = basename.rpartition('.')
-            versioned_basename = '.'.join((name, version, extension))
-        else:
-            versioned_basename += '.' + version
-        self.versions[bundle.name] = versioned_basename
-        versioned_path = os.path.join(dir, versioned_basename)
-        shutil.copy(orig_path, versioned_path)
+        self.versions[bundle.name] = version
 
 
 class MtimeVersioning(VersioningBase):


### PR DESCRIPTION
I have a CSS with the following code for a gradient:

.orange, .orange:visited{
        background: #ff7b00;
        background: -moz-linear-gradient(top,  #ff9b3a 0%, #ff7b00 100%);
        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ff9b3a), color-stop(100%,#ff7b00));
        background: -webkit-linear-gradient(top,  #ff9b3a 0%,#ff7b00 100%);
        background: -o-linear-gradient(top,  #ff9b3a 0%,#ff7b00 100%);
        background: -ms-linear-gradient(top,  #ff9b3a 0%,#ff7b00 100%);
        background: linear-gradient(top,  #ff9b3a 0%,#ff7b00 100%);
        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ff9b3a', endColorstr='#ff7b00',GradientType=0 );
        border-color: #F7AB08;
        color: #fff;
        text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);  
}

The minified code is:

.orange,.orange:visited{background:linear-gradient(top, #ff9b3a 0%,#ff7b00 100%);filter:progid:DXImageTransform.Microsoft.gradient( startColorstr='#ff9b3a', endColorstr='#ff7b00',GradientType=0 );border-color:#F7AB08;color:#fff;text-shadow:0 1px 1px rgba(0, 0, 0, 0.55)}

which doesn't provide the same effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rnk/django-media-bundler/7)
<!-- Reviewable:end -->
